### PR TITLE
Conclusion modification

### DIFF
--- a/app/assets/javascripts/ajax_components.js
+++ b/app/assets/javascripts/ajax_components.js
@@ -91,7 +91,7 @@ function openNewTab(url, containerElementSelector, taskName, callback){
         targetTabLink.html(taskName);
     }
 
-    if(callback != undefined){
+    if(callback == undefined){
         callback = function(){};
     }
 

--- a/app/controllers/conclusions_controller.rb
+++ b/app/controllers/conclusions_controller.rb
@@ -72,7 +72,7 @@ class ConclusionsController < ApplicationController
 			else
 				exhyp = ExerciseHypothesis.find(check_conclusion_params[:exhyp_id])
 				current_user.check_hypothesis(exhyp)
-				format.html { redirect_to task_path(@conclusion.subtask.task, :layout => get_layout, :last_clicked_conclusion => check_conclusion_params[:exhyp_id]), notice: 'Hyvä, väärä työhypoteesi poissuljettu!' }
+				format.html { redirect_to task_path(@conclusion.subtask.task, :layout => get_layout, :last_clicked_conclusion => check_conclusion_params[:exhyp_id]), notice: 'Väärä diffi poissuljettu!' }
 			end
 		end
 	end

--- a/app/controllers/hypotheses_controller.rb
+++ b/app/controllers/hypotheses_controller.rb
@@ -13,6 +13,8 @@ class HypothesesController < ApplicationController
 
       @last_clicked_hypothesis_id = params[:last_clicked_hypothesis_id]
 
+      @correct_diagnosis = @exercise.correct_diagnosis
+
       #new instances
       @new_exercise_hypothesis = ExerciseHypothesis.new
       @new_hypothesis_group = HypothesisGroup.new

--- a/app/models/checked_hypothesis.rb
+++ b/app/models/checked_hypothesis.rb
@@ -13,4 +13,8 @@ class CheckedHypothesis < ActiveRecord::Base
   def get_explanation
     return exercise_hypothesis.get_explanation
   end
+
+  def get_right_explanation
+    return exercise_hypothesis.get_right_explanation
+  end
 end

--- a/app/models/conclusion.rb
+++ b/app/models/conclusion.rb
@@ -3,6 +3,7 @@ class Conclusion < ActiveRecord::Base
 
 	belongs_to :subtask
 	belongs_to :exercise_hypothesis
+	has_one :task, through: :subtask
 
 	def user_answered_correctly?(user, final_conclusion)
 		if final_conclusion.to_i == exercise_hypothesis.id

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -15,19 +15,24 @@ class Exercise < ActiveRecord::Base
   end
 
   def has_conclusion?
-    tasks.each do |task|
-      if !task.conclusions.empty?
-        return true
-      end
-    end
-    return false
+    conclusion = Conclusion.includes(:task).where(tasks:{exercise_id: id})
+    return !conclusion.empty?
   end
 
   def correct_diagnosis
-    tasks.each do |task|
-      if !task.conclusions.empty?
-        return task.conclusions.first.exercise_hypothesis
-      end
+    conclusion = Conclusion.includes(:task).where(tasks:{exercise_id: id})
+
+    unless conclusion.empty?
+      return conclusion.first.exercise_hypothesis
+    end
+    return nil
+  end
+
+  def get_conclusion
+    conclusion = Conclusion.includes(:task).where(tasks:{exercise_id: id})
+
+    unless conclusion.empty?
+      return conclusion.first
     end
     return nil
   end

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -23,6 +23,15 @@ class Exercise < ActiveRecord::Base
     return false
   end
 
+  def correct_diagnosis
+    tasks.each do |task|
+      if !task.conclusions.empty?
+        return task.conclusions.first.exercise_hypothesis
+      end
+    end
+    return nil
+  end
+
   def get_hypotheses
     return exercise_hypotheses.group_by{|exhyp| exhyp.hypothesis.hypothesis_group_id}
   end

--- a/app/models/exercise_hypothesis.rb
+++ b/app/models/exercise_hypothesis.rb
@@ -31,7 +31,14 @@ class ExerciseHypothesis < ActiveRecord::Base
   end
 
   def get_explanation
-    notice = "Työhypoteesi \"" + hypothesis.name + "\" poissuljettu."
+    notice = "\"" + hypothesis.name + "\" poissuljettu."
+    unless explanation.nil?
+      notice += " Perustelu: " + explanation
+    end
+    return notice
+  end
+  def get_right_explanation
+    notice = "Onnittelut! Sait selville, että kyseessä oli " + hypothesis.name  + ". Mitä sinun tulee vielä tehdä?"
     unless explanation.nil?
       notice += " Perustelu: " + explanation
     end

--- a/app/views/hypotheses/index.html.erb
+++ b/app/views/hypotheses/index.html.erb
@@ -1,5 +1,5 @@
 <% if current_user.try(:admin) %>
-  <%= render 'messages/messages' %>
+    <%= render 'messages/messages' %>
 <% end %>
 
 <%# headers %>
@@ -35,15 +35,15 @@
   <div class="col-md-5">
     <%# hypothesis_groups %>
     <% @hypothesis_groups.each do |group| %>
-      <% unless @exercise.get_hypotheses[group.id].nil? %>
-        <%= render 'hypotheses/show/hypothesis_group_header', { group:group } %>
-        <div class="collapse in" id="collapseHypothesisGroup1<%= group.id%>" >
-          <%# hypotheses that belong to current exercise and group%>
-          <%= if current_user.try(:admin)
-              then render 'hypotheses/edit/edit_hypotheses_of_group', { group: group }
-              else render 'hypotheses/show/check_hypotheses_of_group', { group: group }
-              end %>
-        </div>
+        <% unless @exercise.get_hypotheses[group.id].nil? %>
+            <%= render 'hypotheses/show/hypothesis_group_header', { group:group } %>
+            <div class="collapse in" id="collapseHypothesisGroup1<%= group.id%>" >
+              <%# hypotheses that belong to current exercise and group%>
+              <%= if current_user.try(:admin)
+                  then render 'hypotheses/edit/edit_hypotheses_of_group', { group: group }
+                  else render 'hypotheses/show/check_hypotheses_of_group', { group: group }
+                  end %>
+            </div>
         <% end %>
     <% end %>
   </div>
@@ -51,17 +51,23 @@
   </div>
   <div class="col-md-5">
     <% if current_user.try(:admin) %>
-      <% @hypothesis_groups.each do |group| %>
-        <%= render 'hypotheses/edit/hypothesis_group_edit', { group: group }  %>
-        <%= render 'hypotheses/edit/hypotheses_of_group', { group: group }  %>
-      <% end %>
-      <%= render 'hypotheses/edit/new_hypothesis_group'  %>
+        <% @hypothesis_groups.each do |group| %>
+            <%= render 'hypotheses/edit/hypothesis_group_edit', { group: group }  %>
+            <%= render 'hypotheses/edit/hypotheses_of_group', { group: group }  %>
+        <% end %>
+        <%= render 'hypotheses/edit/new_hypothesis_group'  %>
     <% end %>
   </div>
 </div>
 
 <script>
-    setAjaxSubmits("#hypothesisTab form", "#hypothesisTab", "post");
     setRemovables();
+    setAjaxSubmits("#hypothesisTab form", "#hypothesisTab", "post", function(){
+                <% if !current_task.nil? && !current_task.conclusions.empty? %>
+                loadView("/tasks/" + <%= current_task.id.to_s %> , "#currentTaskTab");
+                <% end %>
+            }
+
+    );
     $('[data-toggle="popover"]').popover();
 </script>

--- a/app/views/hypotheses/show/_check_hypotheses_of_group.erb
+++ b/app/views/hypotheses/show/_check_hypotheses_of_group.erb
@@ -8,7 +8,7 @@
         <%= form_for(@new_checked_hypothesis) do |f| %>
           <%= f.hidden_field :exercise_hypothesis_id, :value => exercise_hypothesis.id %>
           <%= f.hidden_field :user_id, :value => current_user.id %>
-          <%= f.submit exercise_hypothesis.hypothesis.name, :class => 'btn btn-default btn-save multiline' %>
+          <%= f.submit exercise_hypothesis.hypothesis.name, :class => 'btn btn-default multiline' %>
         <% end %>
       </div>
       <% if @last_clicked_hypothesis_id == exercise_hypothesis.id.to_s %>

--- a/app/views/hypotheses/show/_checked_hypothesis.html.erb
+++ b/app/views/hypotheses/show/_checked_hypothesis.html.erb
@@ -1,6 +1,6 @@
 <% checked_hypothesis = current_user.get_checked_hypothesis(exercise_hypothesis) %>
 <div class="col-md-8">
-  <input id="checked_hypothesis_<%= checked_hypothesis.id.to_s %>" class="btn btn-default btn-checked multiline" type="button" value="<%= checked_hypothesis.hypothesis.name %>" onclick='showExHypExplanation("#exhyp_explanation_<%= checked_hypothesis.id.to_s %>");'></input>
+  <input id="checked_hypothesis_<%= checked_hypothesis.id.to_s %>" class="btn btn-default <%= (@correct_diagnosis && @correct_diagnosis.hypothesis.id == checked_hypothesis.hypothesis.id) ? "btn-save" : "btn-checked" %> multiline" type="button" value="<%= checked_hypothesis.hypothesis.name %>" onclick='showExHypExplanation("#exhyp_explanation_<%= checked_hypothesis.id.to_s %>");'></input>
 </div>
 <% if @last_clicked_hypothesis_id == checked_hypothesis.exercise_hypothesis.id.to_s %>
   <div class = "col-md-1">

--- a/app/views/hypotheses/show/_checked_hypothesis.html.erb
+++ b/app/views/hypotheses/show/_checked_hypothesis.html.erb
@@ -4,10 +4,10 @@
 </div>
 <% if @last_clicked_hypothesis_id == checked_hypothesis.exercise_hypothesis.id.to_s %>
   <div class = "col-md-1">
-    <div class="info-checked-hypothesis removable" id="exhyp_explanation_<%= checked_hypothesis.id.to_s %>"><%= checked_hypothesis.get_explanation.html_safe %></div>
+    <div class="info-checked-hypothesis removable" id="exhyp_explanation_<%= checked_hypothesis.id.to_s %>"><%= (@correct_diagnosis && @correct_diagnosis.hypothesis.id == checked_hypothesis.hypothesis.id) ? checked_hypothesis.get_right_explanation.html_safe : checked_hypothesis.get_explanation.html_safe %></div>
   </div>
 <% else %>
 	<div class = "col-md-1">
-    <div class="info-checked-hypothesis removable" id="exhyp_explanation_<%= checked_hypothesis.id.to_s %>" style="display:none;"><%= checked_hypothesis.get_explanation.html_safe %></div>
+    <div class="info-checked-hypothesis removable" id="exhyp_explanation_<%= checked_hypothesis.id.to_s %>" style="display:none;"><%= (@correct_diagnosis && @correct_diagnosis.hypothesis.id == checked_hypothesis.hypothesis.id) ? checked_hypothesis.get_right_explanation.html_safe : checked_hypothesis.get_explanation.html_safe  %></div>
   </div>
 <% end %>

--- a/app/views/hypotheses/show/_checked_hypothesis.html.erb
+++ b/app/views/hypotheses/show/_checked_hypothesis.html.erb
@@ -1,13 +1,18 @@
 <% checked_hypothesis = current_user.get_checked_hypothesis(exercise_hypothesis) %>
 <div class="col-md-8">
-  <input id="checked_hypothesis_<%= checked_hypothesis.id.to_s %>" class="btn btn-default <%= (@correct_diagnosis && @correct_diagnosis.hypothesis.id == checked_hypothesis.hypothesis.id) ? "btn-save" : "btn-checked" %> multiline" type="button" value="<%= checked_hypothesis.hypothesis.name %>" onclick='showExHypExplanation("#exhyp_explanation_<%= checked_hypothesis.id.to_s %>");'></input>
+  <input id="checked_hypothesis_<%= checked_hypothesis.id.to_s %>"
+         class="btn btn-default <%= (@correct_diagnosis && @correct_diagnosis.hypothesis.id == checked_hypothesis.hypothesis.id) ? "btn-save" : "btn-checked" %> multiline"
+         type="button"
+         value="<%= checked_hypothesis.hypothesis.name %>"
+         onclick='showExHypExplanation("#exhyp_explanation_<%= checked_hypothesis.id.to_s %>");'></input>
 </div>
-<% if @last_clicked_hypothesis_id == checked_hypothesis.exercise_hypothesis.id.to_s %>
-  <div class = "col-md-1">
-    <div class="info-checked-hypothesis removable" id="exhyp_explanation_<%= checked_hypothesis.id.to_s %>"><%= (@correct_diagnosis && @correct_diagnosis.hypothesis.id == checked_hypothesis.hypothesis.id) ? checked_hypothesis.get_right_explanation.html_safe : checked_hypothesis.get_explanation.html_safe %></div>
+
+
+<div class = "col-md-1">
+  <div class="info-checked-hypothesis removable"
+       id="exhyp_explanation_<%= checked_hypothesis.id.to_s %>"
+       style=<%= @last_clicked_hypothesis_id == checked_hypothesis.exercise_hypothesis.id.to_s ? "" : "display:none;"%>
+  >
+    <%= (@correct_diagnosis && @correct_diagnosis.hypothesis.id == checked_hypothesis.hypothesis.id) ? checked_hypothesis.get_right_explanation.html_safe : checked_hypothesis.get_explanation.html_safe %>
   </div>
-<% else %>
-	<div class = "col-md-1">
-    <div class="info-checked-hypothesis removable" id="exhyp_explanation_<%= checked_hypothesis.id.to_s %>" style="display:none;"><%= (@correct_diagnosis && @correct_diagnosis.hypothesis.id == checked_hypothesis.hypothesis.id) ? checked_hypothesis.get_right_explanation.html_safe : checked_hypothesis.get_explanation.html_safe  %></div>
-  </div>
-<% end %>
+</div>

--- a/app/views/hypotheses/show/_checked_hypothesis.html.erb
+++ b/app/views/hypotheses/show/_checked_hypothesis.html.erb
@@ -11,8 +11,7 @@
 <div class = "col-md-1">
   <div class="info-checked-hypothesis removable"
        id="exhyp_explanation_<%= checked_hypothesis.id.to_s %>"
-       style=<%= @last_clicked_hypothesis_id == checked_hypothesis.exercise_hypothesis.id.to_s ? "" : "display:none;"%>
-  >
+       style=<%= @last_clicked_hypothesis_id == checked_hypothesis.exercise_hypothesis.id.to_s ? "" : "display:none;"%>>
     <%= (@correct_diagnosis && @correct_diagnosis.hypothesis.id == checked_hypothesis.hypothesis.id) ? checked_hypothesis.get_right_explanation.html_safe : checked_hypothesis.get_explanation.html_safe %>
   </div>
 </div>

--- a/app/views/tasks/_task_completed.html.erb
+++ b/app/views/tasks/_task_completed.html.erb
@@ -3,9 +3,9 @@
     <h3 class="panel-title">Toimenpide suoritettu!</h3>
   </div>
   <div class="panel-body">
-    <p>Nyt voit mennä <%= " poissulkemaan diffejä tai " if (current_exercise && current_exercise.has_conclusion? && (task.level < current_exercise.get_conclusion.task.level)) %> suorittamaan lisää toimenpiteitä.</p>
+    <p>Nyt voit mennä <%= " poissulkemaan diffejä tai " if (!current_exercise.has_conclusion? || (current_exercise.has_conclusion? && (task.level < current_exercise.get_conclusion.task.level))) %> suorittamaan lisää toimenpiteitä.</p>
     <div class="row">
-      <% if (current_exercise && current_exercise.has_conclusion? && (task.level < current_exercise.get_conclusion.task.level)) %>
+      <% if (!current_exercise.has_conclusion? || (current_exercise.has_conclusion? && (task.level < current_exercise.get_conclusion.task.level))) %>
           <div class="col-md-3">
             <%= button_to 'Diffilista', hypotheses_path, :class => 'btn btn-default widthAuto', :form_class => "form-task-completed", :form => {id: "form-open-hypotheses-tab"}, :method => :get %>
           </div>

--- a/app/views/tasks/_task_completed.html.erb
+++ b/app/views/tasks/_task_completed.html.erb
@@ -3,9 +3,9 @@
     <h3 class="panel-title">Toimenpide suoritettu!</h3>
   </div>
   <div class="panel-body">
-    <p>Nyt voit mennä <%= " poissulkemaan diffejä tai " if (current_exercise && (task.level < current_exercise.get_conclusion.task.level)) %> suorittamaan lisää toimenpiteitä.</p>
+    <p>Nyt voit mennä <%= " poissulkemaan diffejä tai " if (current_exercise && current_exercise.has_conclusion? && (task.level < current_exercise.get_conclusion.task.level)) %> suorittamaan lisää toimenpiteitä.</p>
     <div class="row">
-      <% if (current_exercise && (task.level < current_exercise.get_conclusion.task.level)) %>
+      <% if (current_exercise && current_exercise.has_conclusion? && (task.level < current_exercise.get_conclusion.task.level)) %>
           <div class="col-md-3">
             <%= button_to 'Diffilista', hypotheses_path, :class => 'btn btn-default widthAuto', :form_class => "form-task-completed", :form => {id: "form-open-hypotheses-tab"}, :method => :get %>
           </div>

--- a/app/views/tasks/_task_completed.html.erb
+++ b/app/views/tasks/_task_completed.html.erb
@@ -3,11 +3,13 @@
     <h3 class="panel-title">Toimenpide suoritettu!</h3>
   </div>
   <div class="panel-body">
-    <p>Nyt voit mennä poissulkemaan työhypoteeseja tai suorittamaan lisää toimenpiteitä.</p>
+    <p>Nyt voit mennä <%= " poissulkemaan diffejä tai " if task.conclusions.empty?%> suorittamaan lisää toimenpiteitä.</p>
     <div class="row">
-      <div class="col-md-3">
-        <%= button_to 'Työhypoteesilista', hypotheses_path, :class => 'btn btn-default widthAuto', :form_class => "form-task-completed", :form => {id: "form-open-hypotheses-tab"}, :method => :get %>
-      </div>
+      <% if task.conclusions.empty?%>
+          <div class="col-md-3">
+            <%= button_to 'Diffilista', hypotheses_path, :class => 'btn btn-default widthAuto', :form_class => "form-task-completed", :form => {id: "form-open-hypotheses-tab"}, :method => :get %>
+          </div>
+      <% end %>
       <div class="col-md-3">
         <%= button_to 'Toimenpidelista', tasks_path, :class => 'btn btn-default widthAuto', :form_class => "form-task-completed", :form => {id: "form-open-tasks-tab"}, :method => :get %>
       </div>

--- a/app/views/tasks/_task_completed.html.erb
+++ b/app/views/tasks/_task_completed.html.erb
@@ -3,9 +3,9 @@
     <h3 class="panel-title">Toimenpide suoritettu!</h3>
   </div>
   <div class="panel-body">
-    <p>Nyt voit mennä <%= " poissulkemaan diffejä tai " if task.conclusions.empty?%> suorittamaan lisää toimenpiteitä.</p>
+    <p>Nyt voit mennä <%= " poissulkemaan diffejä tai " if (current_exercise && (task.level < current_exercise.get_conclusion.task.level)) %> suorittamaan lisää toimenpiteitä.</p>
     <div class="row">
-      <% if task.conclusions.empty?%>
+      <% if (current_exercise && (task.level < current_exercise.get_conclusion.task.level)) %>
           <div class="col-md-3">
             <%= button_to 'Diffilista', hypotheses_path, :class => 'btn btn-default widthAuto', :form_class => "form-task-completed", :form => {id: "form-open-hypotheses-tab"}, :method => :get %>
           </div>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -29,7 +29,9 @@
 <script>
     //STUDENT
     //open task button for student
-    setNewTabSubmits("#taskTab .form-to-task-student", "#currentTaskTab");
+    setNewTabSubmits("#taskTab .form-to-task-student", "#currentTaskTab", function(){
+        loadView("/hypotheses", "#hypothesisTab");
+    });
     //submits for task that cannot be done
     setAjaxSubmits("#taskTab .form-cannot-task-student", "#taskTab", "get");
     //open completed task

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -25,7 +25,7 @@
 <% end %>
 
 <% if current_user.has_completed?(@task) %>
-    <%= render 'task_completed' %>
+    <%= render 'task_completed', {task:@task} %>
 <% end %>
 
 <script>

--- a/app/views/tasks/subtasks/_ask_conclusion.html.erb
+++ b/app/views/tasks/subtasks/_ask_conclusion.html.erb
@@ -33,8 +33,7 @@
 
                 <div class="info-checked-hypothesis removable"
                      id="exhyp_explanation_<%= exhyp.id.to_s %>"
-                     style=<%= (@last_clicked_conclusion && (@last_clicked_conclusion.id == exhyp.id)) ? "" : "display:none;"%>
-                >
+                     style=<%= (@last_clicked_conclusion && (@last_clicked_conclusion.id == exhyp.id)) ? "" : "display:none;"%>>
                   <%= exhyp.get_explanation.html_safe %>
                 </div>
               </div>

--- a/app/views/tasks/subtasks/_ask_conclusion.html.erb
+++ b/app/views/tasks/subtasks/_ask_conclusion.html.erb
@@ -22,17 +22,22 @@
           <% else %>
 
               <div class = "col-md-4">
-                <input id="checked_hypothesis_<%= exhyp.id.to_s %>" class="btn btn-default btn-checked multiline" type="button" value="<%= exhyp.hypothesis.name %>" onclick='showExHypExplanation("#exhyp_explanation_<%= exhyp.id.to_s %>");'></input>
+                <input id="checked_hypothesis_<%= exhyp.id.to_s %>"
+                       class="btn btn-default btn-checked multiline"
+                       type="button"
+                       value="<%= exhyp.hypothesis.name %>"
+                       onclick='showExHypExplanation("#exhyp_explanation_<%= exhyp.id.to_s %>");'></input>
               </div>
 
               <div class = "col-md-8">
-                <% if @last_clicked_conclusion && (@last_clicked_conclusion.id.to_s == exhyp.id.to_s) %>
-                    <div class="info-checked-hypothesis removable" id="exhyp_explanation_<%= exhyp.id.to_s %>"><%= exhyp.get_explanation.html_safe %></div>
-                <% else %>
-                    <div class="info-checked-hypothesis removable" id="exhyp_explanation_<%= exhyp.id.to_s %>" style="display:none;"><%= exhyp.get_explanation.html_safe %></div>
-                <% end %>
-              </div>
 
+                <div class="info-checked-hypothesis removable"
+                     id="exhyp_explanation_<%= exhyp.id.to_s %>"
+                     style=<%= (@last_clicked_conclusion && (@last_clicked_conclusion.id == exhyp.id)) ? "" : "display:none;"%>
+                >
+                  <%= exhyp.get_explanation.html_safe %>
+                </div>
+              </div>
           <% end %>
         </div>
     <%end%>

--- a/app/views/tasks/subtasks/_ask_conclusion.html.erb
+++ b/app/views/tasks/subtasks/_ask_conclusion.html.erb
@@ -3,7 +3,7 @@
 
 <br>
 
-<h4>Jäljellä olevat työhypoteesit:</h4>
+<h4>Diffilistassa jäljellä:</h4>
 <br/>
 
 <% unless current_user.try(:admin) %>

--- a/app/views/tasks/subtasks/_completed_conclusion.html.erb
+++ b/app/views/tasks/subtasks/_completed_conclusion.html.erb
@@ -4,8 +4,6 @@
     <%= render 'tasks/subtasks/ask_conclusion', { subtask:subtask } %>
 <% end %>
 
-<!--<p>Onnittelut! Sait selville, että kyseessä oli <%#= subtask_exhyp.hypothesis.name %>. Mitä sinun tulee vielä tehdä? </p>-->
-
 <% if !@conclusion_exercise_hypotheses.empty? && !current_user.try(:admin)%>
 
     <h4>Poissuljetut diffit:</h4>
@@ -13,24 +11,25 @@
     <% @conclusion_exercise_hypotheses.each do |exhyp| %>
 
         <div class = "row">
-          <% if exhyp.id ==  subtask_exhyp.id %>
-              <div class = "col-md-4">
-                <input id="checked_hypothesis_<%= exhyp.id.to_s %>" class="btn btn-default btn-save multiline" type="button" value="<%= exhyp.hypothesis.name %>" onclick='showExHypExplanation("#exhyp_explanation_<%= exhyp.id.to_s %>");'></input>
-              </div>
+          <div class = "col-md-4">
+            <input id="checked_hypothesis_<%= exhyp.id.to_s %>"
+                   class="btn btn-default
+                       <%= exhyp.id ==  subtask_exhyp.id ? "btn-save" : "btn-checked"%>
+                       multiline"
+                   type="button"
+                   value="<%= exhyp.hypothesis.name %>"
+                   onclick='showExHypExplanation("#exhyp_explanation_<%= exhyp.id.to_s %>");'></input>
+          </div>
 
-          <% else %>
-              <div class = "col-md-4">
-                <input id="checked_hypothesis_<%= exhyp.id.to_s %>" class="btn btn-default btn-checked multiline" type="button" value="<%= exhyp.hypothesis.name %>" onclick='showExHypExplanation("#exhyp_explanation_<%= exhyp.id.to_s %>");'></input>
-              </div>
-
-          <% end %>
           <div class = "col-md-8">
-            <% if @last_clicked_conclusion && (@last_clicked_conclusion.id == exhyp.id) %>
 
-                <div class="info-checked-hypothesis removable" id="exhyp_explanation_<%= exhyp.id.to_s %>"><%= (exhyp.id == subtask_exhyp.id) ? exhyp.get_right_explanation.html_safe : exhyp.get_explanation.html_safe %></div>
-            <% else %>
-                <div class="info-checked-hypothesis removable" id="exhyp_explanation_<%= exhyp.id.to_s %>" style="display:none;"><%= (exhyp.id == subtask_exhyp.id) ? exhyp.get_right_explanation.html_safe : exhyp.get_explanation.html_safe %></div>
-            <% end %>
+            <div class="info-checked-hypothesis removable"
+                 id="exhyp_explanation_<%= exhyp.id.to_s %>"
+                 style=<%= (@last_clicked_conclusion && (@last_clicked_conclusion.id == exhyp.id)) ? "" : "display:none;"%>
+            >
+              <%= (exhyp.id == subtask_exhyp.id) ? exhyp.get_right_explanation.html_safe : exhyp.get_explanation.html_safe %>
+            </div>
+
           </div>
 
         </div>
@@ -46,7 +45,7 @@
         <input id="checked_hypothesis_<%= subtask_exhyp.id.to_s %>" class="btn btn-default btn-save multiline" type="button" value="<%= subtask_exhyp.hypothesis.name %>" onclick='showExHypExplanation("#exhyp_explanation_<%= subtask_exhyp.id.to_s %>");'></input>
       </div>
       <div class = "col-md-8">
-        <div class="info-checked-hypothesis removable" id="exhyp_explanation_<%= subtask_exhyp.id.to_s %>" style="display:none;">Onnittelut! Sait selville, että kyseessä oli <%= subtask_exhyp.hypothesis.name %>. Mitä sinun tulee vielä tehdä?</div>
+        <div class="info-checked-hypothesis removable" id="exhyp_explanation_<%= subtask_exhyp.id.to_s %>" style="display:none;"><%= subtask_exhyp.get_right_explanation.html_safe %></div>
       </div>
 
     </div>

--- a/app/views/tasks/subtasks/_completed_conclusion.html.erb
+++ b/app/views/tasks/subtasks/_completed_conclusion.html.erb
@@ -25,8 +25,7 @@
 
             <div class="info-checked-hypothesis removable"
                  id="exhyp_explanation_<%= exhyp.id.to_s %>"
-                 style=<%= (@last_clicked_conclusion && (@last_clicked_conclusion.id == exhyp.id)) ? "" : "display:none;"%>
-            >
+                 style=<%= (@last_clicked_conclusion && (@last_clicked_conclusion.id == exhyp.id)) ? "" : "display:none;"%>>
               <%= (exhyp.id == subtask_exhyp.id) ? exhyp.get_right_explanation.html_safe : exhyp.get_explanation.html_safe %>
             </div>
 
@@ -42,10 +41,18 @@
     <div class = "row">
 
       <div class = "col-md-4">
-        <input id="checked_hypothesis_<%= subtask_exhyp.id.to_s %>" class="btn btn-default btn-save multiline" type="button" value="<%= subtask_exhyp.hypothesis.name %>" onclick='showExHypExplanation("#exhyp_explanation_<%= subtask_exhyp.id.to_s %>");'></input>
+        <input id="checked_hypothesis_<%= subtask_exhyp.id.to_s %>"
+               class="btn btn-default btn-save multiline"
+               type="button"
+               value="<%= subtask_exhyp.hypothesis.name %>"
+               onclick='showExHypExplanation("#exhyp_explanation_<%= subtask_exhyp.id.to_s %>");'></input>
       </div>
       <div class = "col-md-8">
-        <div class="info-checked-hypothesis removable" id="exhyp_explanation_<%= subtask_exhyp.id.to_s %>" style="display:none;"><%= subtask_exhyp.get_right_explanation.html_safe %></div>
+        <div class="info-checked-hypothesis removable"
+             id="exhyp_explanation_<%= subtask_exhyp.id.to_s %>"
+             style="display:none;">
+          <%= subtask_exhyp.get_right_explanation.html_safe %>
+        </div>
       </div>
 
     </div>

--- a/app/views/tasks/subtasks/_completed_conclusion.html.erb
+++ b/app/views/tasks/subtasks/_completed_conclusion.html.erb
@@ -4,13 +4,11 @@
     <%= render 'tasks/subtasks/ask_conclusion', { subtask:subtask } %>
 <% end %>
 
-<p>Onnittelut! Sait selville, että kyseessä oli <%= subtask_exhyp.hypothesis.name %>. Mitä sinun tulee vielä tehdä? </p>
-
-<br/>
+<!--<p>Onnittelut! Sait selville, että kyseessä oli <%#= subtask_exhyp.hypothesis.name %>. Mitä sinun tulee vielä tehdä? </p>-->
 
 <% if !@conclusion_exercise_hypotheses.empty? && !current_user.try(:admin)%>
 
-    <h4>Poissuljetut työhypoteesit:</h4>
+    <h4>Poissuljetut diffit:</h4>
 
     <% @conclusion_exercise_hypotheses.each do |exhyp| %>
 
@@ -27,10 +25,11 @@
 
           <% end %>
           <div class = "col-md-8">
-            <% if @last_clicked_conclusion && (@last_clicked_conclusion.id.to_s == exhyp.id.to_s) %>
-                <div class="info-checked-hypothesis removable" id="exhyp_explanation_<%= exhyp.id.to_s %>"><%= exhyp.get_explanation.html_safe %></div>
+            <% if @last_clicked_conclusion && (@last_clicked_conclusion.id == exhyp.id) %>
+
+                <div class="info-checked-hypothesis removable" id="exhyp_explanation_<%= exhyp.id.to_s %>"><%= (exhyp.id == subtask_exhyp.id) ? exhyp.get_right_explanation.html_safe : exhyp.get_explanation.html_safe %></div>
             <% else %>
-                <div class="info-checked-hypothesis removable" id="exhyp_explanation_<%= exhyp.id.to_s %>" style="display:none;"><%= exhyp.get_explanation.html_safe %></div>
+                <div class="info-checked-hypothesis removable" id="exhyp_explanation_<%= exhyp.id.to_s %>" style="display:none;"><%= (exhyp.id == subtask_exhyp.id) ? exhyp.get_right_explanation.html_safe : exhyp.get_explanation.html_safe %></div>
             <% end %>
           </div>
 
@@ -47,7 +46,7 @@
         <input id="checked_hypothesis_<%= subtask_exhyp.id.to_s %>" class="btn btn-default btn-save multiline" type="button" value="<%= subtask_exhyp.hypothesis.name %>" onclick='showExHypExplanation("#exhyp_explanation_<%= subtask_exhyp.id.to_s %>");'></input>
       </div>
       <div class = "col-md-8">
-        <div class="info-checked-hypothesis removable" id="exhyp_explanation_<%= subtask_exhyp.id.to_s %>" style="display:none;"><%= subtask_exhyp.get_explanation.html_safe %></div>
+        <div class="info-checked-hypothesis removable" id="exhyp_explanation_<%= subtask_exhyp.id.to_s %>" style="display:none;">Onnittelut! Sait selville, että kyseessä oli <%= subtask_exhyp.hypothesis.name %>. Mitä sinun tulee vielä tehdä?</div>
       </div>
 
     </div>

--- a/spec/features/complete_conclusion_page_spec.rb
+++ b/spec/features/complete_conclusion_page_spec.rb
@@ -93,7 +93,7 @@ describe "Conclusion page for student", js:true do
           click_and_wait("Kurkkukipu")
         }.not_to change(CompletedTask, :count)
 
-        expect(page).to have_content "Hyvä, väärä työhypoteesi poissuljettu!"
+        expect(page).to have_content "Väärä diffi poissuljettu!"
 
         expect {
           click_and_wait("Bakteeritauti")

--- a/spec/features/complete_conclusion_page_spec.rb
+++ b/spec/features/complete_conclusion_page_spec.rb
@@ -80,6 +80,7 @@ describe "Conclusion page for student", js:true do
         expect(page).to have_content "Onnittelut! Sait selville, että kyseessä oli Bakteeritauti. Mitä sinun tulee vielä tehdä?"
         expect(page).to have_content 'Toimenpide suoritettu!'
         expect(page).to have_content 'Nyt voit mennä suorittamaan lisää toimenpiteitä.'
+        expect(page).to have_content 'Poissuljetut diffit:'
         expect(page).not_to have_content 'poissulkemaan diffejä tai'
 
         expect(page).to have_button 'Toimenpidelista'
@@ -179,7 +180,8 @@ describe "Conclusion page for student", js:true do
       end
 
       it "should be able to view the contents of the conclusion" do
-        expect(page).to have_content "Onnittelut! Sait selville, että kyseessä oli Bakteeritauti. Mitä sinun tulee vielä tehdä?"
+
+        expect(page).to have_content "Poissuljetut diffit:"
       end
 
       it "should be able to view the explanation for right conclusion" do

--- a/spec/features/complete_conclusion_page_spec.rb
+++ b/spec/features/complete_conclusion_page_spec.rb
@@ -39,9 +39,8 @@ describe "Conclusion page for student", js:true do
 
       it "the title and the content of the conclusion" do
 
-
         expect(page).to have_content "Diagnoosi"
-        expect(page).to have_content "Valitse tästä oikea diagnoosi"
+        expect(page).to have_content "Diffilistassa jäljellä:"
       end
 
       it "all remaining hypotheses" do
@@ -79,7 +78,12 @@ describe "Conclusion page for student", js:true do
 
         expect(page).to have_content "Hyvä, selvitit oikean diagnoosin!"
         expect(page).to have_content "Onnittelut! Sait selville, että kyseessä oli Bakteeritauti. Mitä sinun tulee vielä tehdä?"
-        #expect(page).to have_content 'Toimenpide suoritettu!'
+        expect(page).to have_content 'Toimenpide suoritettu!'
+        expect(page).to have_content 'Nyt voit mennä suorittamaan lisää toimenpiteitä.'
+        expect(page).not_to have_content 'poissulkemaan diffejä tai'
+
+        expect(page).to have_button 'Toimenpidelista'
+        expect(page).not_to have_button 'Diffilista'
       end
 
 
@@ -95,7 +99,7 @@ describe "Conclusion page for student", js:true do
         }.to change(CompletedTask, :count).by(1)
 
         expect(page).to have_content "Onnittelut! Sait selville, että kyseessä oli Bakteeritauti. Mitä sinun tulee vielä tehdä?"
-        # expect(page).to have_content 'Toimenpide suoritettu!'
+        expect(page).to have_content 'Toimenpide suoritettu!'
       end
 
       it "all wrong answers" do
@@ -107,7 +111,7 @@ describe "Conclusion page for student", js:true do
         }.to change(CompletedTask, :count).by(1)
 
         expect(page).to have_content "Onnittelut! Sait selville, että kyseessä oli Bakteeritauti. Mitä sinun tulee vielä tehdä?"
-        # expect(page).to have_content 'Toimenpide suoritettu!'
+        expect(page).to have_content 'Toimenpide suoritettu!'
       end
 
     end

--- a/spec/features/new_conclusion_page_spec.rb
+++ b/spec/features/new_conclusion_page_spec.rb
@@ -138,7 +138,7 @@ describe "New Conclusion page", js:true do
           expect(page).to have_content "Diagnoositoimenpide"
           expect(page).to have_content "Tehtäväsi:"
           expect(page).to have_content "Valitse oikea diagnoosi!"
-          expect(page).to have_content "Jäljellä olevat työhypoteesit:"
+          expect(page).to have_content "Diffilistassa jäljellä:"
           expect(page).to have_content "Onnittelut! Sait selville, että kyseessä oli Virustauti. Mitä sinun tulee vielä tehdä?"
           expect(page).to have_content "Oikea diagnoosi:"
           expect(page).to have_button "Virustauti"

--- a/spec/features/new_conclusion_page_spec.rb
+++ b/spec/features/new_conclusion_page_spec.rb
@@ -139,7 +139,6 @@ describe "New Conclusion page", js:true do
           expect(page).to have_content "Tehtäväsi:"
           expect(page).to have_content "Valitse oikea diagnoosi!"
           expect(page).to have_content "Diffilistassa jäljellä:"
-          expect(page).to have_content "Onnittelut! Sait selville, että kyseessä oli Virustauti. Mitä sinun tulee vielä tehdä?"
           expect(page).to have_content "Oikea diagnoosi:"
           expect(page).to have_button "Virustauti"
 

--- a/spec/features/show_task_page_spec.rb
+++ b/spec/features/show_task_page_spec.rb
@@ -49,7 +49,7 @@ describe "Task show page", js:true do
       describe "question and answer options for a" do
 
         it "multichoice task" do
-          click_button(multichoice_task.name)
+          click_and_wait(multichoice_task.name)
 
           expect(page).to have_content multichoice.question
           expect(page).to have_content option.content
@@ -58,7 +58,7 @@ describe "Task show page", js:true do
         end
 
         it "radiobutton task" do
-          click_button(radiobutton_task.name)
+          click_and_wait(radiobutton_task.name)
 
           expect(page).to have_content radiobutton.question
           expect(page).to have_content option4.content

--- a/spec/features/show_user_page_spec.rb
+++ b/spec/features/show_user_page_spec.rb
@@ -37,13 +37,13 @@ describe "User show page", js:true do
 
       describe "change" do
         before :each do
-          click_button 'Muokkaa tietoja'
+          click_and_wait 'Muokkaa tietoja'
         end
 
         it "password" do
           fill_in 'user_password', with: 'Salaisuus'
           fill_in 'user_password_confirmation', with: 'Salaisuus'
-          click_button 'Päivitä salasana'
+          click_and_wait 'Päivitä salasana'
           expect(page).to have_content 'Käyttäjän tiedot päivitetty'
 
           updated_student = User.where(username:"Opiskelija").first
@@ -53,7 +53,7 @@ describe "User show page", js:true do
           expect(updated_student.student_number).to eq(student.student_number)
           expect(updated_student.starting_year).to eq(student.starting_year)
 
-          click_button 'Kirjaudu ulos'
+          click_and_wait 'Kirjaudu ulos'
           sign_in(username:"Opiskelija", password:"Salaisuus")
           expect(page).to have_content 'Tervetuloa takaisin!'
         end
@@ -61,7 +61,7 @@ describe "User show page", js:true do
         it "other information without changing password" do
           fill_in 'user_realname', with: 'Uusi hassu nimi'
           fill_in 'user_email', with: 'uusi@nimi.com'
-          click_button 'Päivitä'
+          click_and_wait 'Päivitä'
           expect(page).to have_content 'Käyttäjän tiedot päivitetty'
 
           updated_student = User.where(username:"Opiskelija").first
@@ -71,7 +71,7 @@ describe "User show page", js:true do
           expect(updated_student.student_number).to eq(student.student_number)
           expect(updated_student.starting_year).to eq(student.starting_year)
 
-          click_button 'Kirjaudu ulos'
+          click_and_wait 'Kirjaudu ulos'
           sign_in(username:"Opiskelija", password:"Salainen1")
           expect(page).to have_content 'Tervetuloa takaisin!'
         end
@@ -106,9 +106,9 @@ describe "User show page", js:true do
       end
 
       it "update information wrong" do
-        click_button 'Muokkaa tietoja'
+        click_and_wait 'Muokkaa tietoja'
         fill_in 'user_realname', with: ''
-        click_button 'Päivitä'
+        click_and_wait 'Päivitä'
         expect(page).to have_content 'Seuraavat virheet estivät tallennuksen:'
       end
     end

--- a/spec/features/users_page_spec.rb
+++ b/spec/features/users_page_spec.rb
@@ -37,7 +37,7 @@ describe "Users page", js:true do
 
     describe "should be able to" do
       it "visit users page and see all exercises" do
-        click_button('Opiskelijoiden seuranta')
+        click_and_wait('Opiskelijoiden seuranta')
         expect(current_path).to eq(users_path)
         expect(page).to have_content 'Opiskelijoiden tiedot'
         expect(page).to have_content 'Lihanautakuolemat'
@@ -49,7 +49,7 @@ describe "Users page", js:true do
       end
 
       it "visit list of all students" do
-        click_button('Opiskelijoiden seuranta')
+        click_and_wait('Opiskelijoiden seuranta')
         select 'Opiskelijalista', from: 'list_type'
         expect(page).to have_content student.realname
         expect(page).to have_content student2.realname
@@ -84,7 +84,7 @@ describe "Users page", js:true do
         let!(:completed_task5){FactoryGirl.create(:completed_task, task:task, user:student3)}
 
         it "visit users page and see all users that have started exercises" do
-          click_button('Opiskelijoiden seuranta')
+          click_and_wait('Opiskelijoiden seuranta')
           expect(page).to have_content student.realname
           expect(page).to have_content student2.realname
           expect(page).to have_content student3.realname
@@ -97,7 +97,7 @@ describe "Users page", js:true do
         describe "in users page" do
 
           before :each do
-            click_button('Opiskelijoiden seuranta')
+            click_and_wait('Opiskelijoiden seuranta')
           end
 
           it "view users of one exercise" do

--- a/spec/models/exercise_hypothesis_spec.rb
+++ b/spec/models/exercise_hypothesis_spec.rb
@@ -28,8 +28,12 @@ RSpec.describe ExerciseHypothesis, :type => :model do
 
     let!(:exercise_hypothesis){FactoryGirl.create(:exercise_hypothesis, exercise:exercise, hypothesis:hypothesis)}
 
-    it "returns right explanation" do
-      expect(exercise_hypothesis.get_explanation).to eq('Työhypoteesi "Virustauti" poissuljettu. Perustelu: Anamneesin mukaan tauti on virustauti')
+    it "returns the normal explanation" do
+      expect(exercise_hypothesis.get_explanation).to eq('"Virustauti" poissuljettu. Perustelu: Anamneesin mukaan tauti on virustauti')
+    end
+
+    it "returns the right explanation" do
+      expect(exercise_hypothesis.get_right_explanation).to eq('Onnittelut! Sait selville, että kyseessä oli Virustauti. Mitä sinun tulee vielä tehdä? Perustelu: Anamneesin mukaan tauti on virustauti')
     end
 
   end

--- a/spec/models/exercise_spec.rb
+++ b/spec/models/exercise_spec.rb
@@ -81,4 +81,22 @@ describe Exercise do
       expect(has_no_conclusion.has_conclusion?).to eq(false)
     end
   end
+
+  describe "correct_diagnosis" do
+    let!(:has_conclusion){FactoryGirl.create(:exercise)}
+    let!(:has_no_conclusion){FactoryGirl.create(:exercise)}
+    let!(:task){FactoryGirl.create(:task, exercise:has_conclusion)}
+    let!(:subtask){FactoryGirl.create(:subtask, task:task)}
+    let!(:hypothesis){FactoryGirl.create(:hypothesis)}
+    let!(:exercise_hypothesis){FactoryGirl.create(:exercise_hypothesis, exercise:has_conclusion, hypothesis:hypothesis)}
+    let!(:conclusion){FactoryGirl.create(:conclusion, subtask:subtask, exercise_hypothesis:exercise_hypothesis)}
+
+    it "returns right exercise hypothesis if exercise has conclusion" do
+      expect(has_conclusion.correct_diagnosis.hypothesis.name).to eq("Virustauti")
+    end
+
+    it "returns nil if exercise doesn't have conclusion" do
+      expect(has_no_conclusion.correct_diagnosis).to eq(nil)
+    end
+  end
 end

--- a/spec/models/exercise_spec.rb
+++ b/spec/models/exercise_spec.rb
@@ -99,4 +99,22 @@ describe Exercise do
       expect(has_no_conclusion.correct_diagnosis).to eq(nil)
     end
   end
+
+  describe "get_conclusion" do
+    let!(:has_conclusion){FactoryGirl.create(:exercise)}
+    let!(:has_no_conclusion){FactoryGirl.create(:exercise)}
+    let!(:task){FactoryGirl.create(:task, exercise:has_conclusion)}
+    let!(:subtask){FactoryGirl.create(:subtask, task:task)}
+    let!(:conclusion){FactoryGirl.create(:conclusion, subtask:subtask)}
+
+    it "returns right conclusion if exercise has conclusion" do
+      exercise_conclusion = has_conclusion.get_conclusion
+      expect(exercise_conclusion.title).to eq("Viimekysymys")
+      expect(exercise_conclusion.content).to eq("Valitse tästä oikea diagnoosi")
+    end
+
+    it "returns nil if exercise doesn't have conclusion" do
+      expect(has_no_conclusion.get_conclusion).to eq(nil)
+    end
+  end
 end


### PR DESCRIPTION
Modifications in complete conclusion view: 
- No more "Työhypoteesit" when checking out exercise hypothesis
- When getting the right diagnosis the info will be next to the diagnosis
- After completing conclusion page does not say to go check more hypotheses

Modifications in hypotheses view:
- No more "Työhypoteesit" when checking out exercise hypothesis
- Page co-operates with complete conclusion view when checking out exercise hypotheses

Modifications in exercise model:
- Refactored conclusion related methods and added new conclusion related methods